### PR TITLE
upgrade dependencies, support for actix-web v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ features = [ "v4" ]
 
 [dev-dependencies]
 actix-rt = "2.7.0"
+actix-web = "4.1.0"
 bytes = "1.2.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,18 @@ readme = "README.md"
 version = "0.2.0"
 
 [dependencies]
-actix-web = { version = "3.0.0", default-features = false }
+actix-web = { version = "4.1.0", default-features = false }
 futures = "0.3.4"
 
 [dependencies.uuid]
 optional = true
-version = "0.8.1"
+version = "1.1.2"
 default-features = false
 features = [ "v4" ]
 
 [dev-dependencies]
-actix-rt = "1.1.0"
-bytes = "0.5.4"
+actix-rt = "2.7.0"
+bytes = "1.2.1"
 
 [features]
 default = [ "uuid-generator" ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Actix Request Identifier Middleware
 
 [![Latest Version](https://img.shields.io/crates/v/actix-request-identifier.svg)](https://crates.io/crates/actix-request-identifier)
-[![Documentation](https://docs.rs/https://docs.rs/actix-request-identifiermio/badge.svg)](https://docs.rs/actix-request-identifier)
+[![Documentation](https://docs.rs/actix-request-identifier/badge.svg)](https://docs.rs/actix-request-identifier)
 ![Rust](https://github.com/vbrandl/actix-request-identifier/workflows/Rust/badge.svg)
 [![Hits-of-Code](https://hitsofcode.com/github/vbrandl/actix-request-identifier)](https://hitsofcode.com/view/github/vbrandl/actix-request-identifier)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/vbrandl/merging-iterator/blob/master/LICENSE-MIT)
@@ -49,6 +49,14 @@ date: Mon, 20 Apr 2020 06:53:49 GMT
 
 5f099854-2117-49b3-b252-d6693a85acc5
 ```
+
+## Supported `actix-web` Versions
+
+| crate version | `actix-web` version |
+| ------------- | ------------------- |
+| `0.1.0`       | `v2`                |
+| `0.2.0`       | `v3`                |
+| `4.0.0`       | `v4`                |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,23 +18,24 @@ the request using `RequestId`.
 
 ```rust
 use actix_request_identifier::{RequestId, RequestIdentifier};
+use actix_web::{get, App, HttpServer, Responder};
 
 #[get("/")]
-async fn index(id: RequestId) -> impl Responder {
-    HttpResponse::Ok().body(format!("{}", id.as_str()))
+async fn show_request_id(id: RequestId) -> impl Responder {
+    format!("{}", id.as_str())
 }
 
-#[actix_rt::main]
-async fn main() {
-    HttpServer::new(move || {
+#[actix_web::main] // or #[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let http_server = HttpServer::new(|| {
         App::new()
+            .service(show_request_id)
             .wrap(RequestIdentifier::with_uuid())
-            .service(index)
-    }).bind("127.0.0.1:8080")
-    .unwrap()
+    })
+    .bind(("127.0.0.1", 8080))?
     .run()
     .await
-    .unwrap();
+}
 ```
 
 The response looks like this:
@@ -54,5 +55,5 @@ date: Mon, 20 Apr 2020 06:53:49 GMT
 `actix-request-identifier` is licensed under either of the following at your
 option:
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ async fn show_request_id(id: RequestId) -> impl Responder {
 
 #[actix_web::main] // or #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    let http_server = HttpServer::new(|| {
+    HttpServer::new(|| {
         App::new()
             .service(show_request_id)
             .wrap(RequestIdentifier::with_uuid())

--- a/examples/actix-web.rs
+++ b/examples/actix-web.rs
@@ -1,0 +1,21 @@
+use actix_request_identifier::{RequestId, RequestIdentifier};
+use actix_web::{get, App, HttpServer, Responder};
+
+#[get("/")]
+async fn show_request_id(id: RequestId) -> impl Responder {
+    format!("{}", id.as_str())
+}
+
+#[actix_web::main] // or #[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let http_server = HttpServer::new(|| {
+        App::new()
+            .service(show_request_id)
+            .wrap(RequestIdentifier::with_uuid())
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run();
+    println!("example server listening on 127.0.0.1:8080");
+    println!("try `curl -v http://127.0.0.1:8080/`");
+    http_server.await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ impl FromRequest for RequestId {
 mod tests {
     use super::*;
     use actix_web::{test, web, App};
-    use bytes::{Buf, Bytes};
+    use bytes::Bytes;
 
     async fn handler(id: RequestId) -> String {
         id.as_str().to_string()
@@ -230,7 +230,7 @@ mod tests {
             .map(|v| v.to_str().unwrap().to_string())
             .unwrap();
         let body: Bytes = test::read_body(resp).await;
-        let body = String::from_utf8_lossy(body.bytes());
+        let body = String::from_utf8_lossy(&body);
         assert_eq!(uid, body);
     }
 
@@ -246,7 +246,7 @@ mod tests {
             .map(|v| v.to_str().unwrap().to_string())
             .unwrap();
         let body: Bytes = test::read_body(resp).await;
-        let body = String::from_utf8_lossy(body.bytes());
+        let body = String::from_utf8_lossy(&body);
         assert_eq!(uid, body);
     }
 
@@ -263,7 +263,7 @@ mod tests {
             .map(|v| v.to_str().unwrap().to_string())
             .unwrap();
         let body: Bytes = test::read_body(resp).await;
-        let body = String::from_utf8_lossy(body.bytes());
+        let body = String::from_utf8_lossy(&body);
         assert_eq!(uid, body);
     }
 }


### PR DESCRIPTION
this PR upgrades the dependencies to their latest stable releases

notably, it now supports the current stable actix-web v4 middleware changes

this does, however, break support for previous actix-web v3